### PR TITLE
Debian packakes can be installed via URL (for dev releases e.g.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ FileBeat version to use.
 
     filebeat_version: 1.1.1
 
+On Debian based Systems you may use a URL to install a specific .deb
+To do so set 
+
+    filebeat_use_apt_repo: false (default true)
+
+The following deb base url is set by default:
+
+    filebeat_deb_baseurl: "https://download.elastic.co/beats/filebeat"
+
 Start FileBeat at boot time.
 
     filebeat_start_at_boot: true

--- a/README.md
+++ b/README.md
@@ -35,12 +35,14 @@ FileBeat version to use.
 
     filebeat_version: 1.1.1
 
-On Debian based Systems you may use a URL to install a specific .deb
-To do so set 
+Make use of the FileBeat apt repo.
+On Debian-based systems, you may use a URL to install a specific `.deb`.
+To do so, change `filebeat_use_apt_repo` value to `false`, then (optionally)
+adjust the value of `filebeat_deb_baseurl` (which has a default value set for you).
 
-    filebeat_use_apt_repo: false (default true)
+    filebeat_use_apt_repo: true
 
-The following deb base url is set by default:
+FileBeat `.deb` base URL for package download if `filebeat_use_apt_repo: false`
 
     filebeat_deb_baseurl: "https://download.elastic.co/beats/filebeat"
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ FileBeat version to use.
     filebeat_version: 1.1.1
 
 Make use of the FileBeat apt repo.
+
 On Debian-based systems, you may use a URL to install a specific `.deb`.
 To do so, change `filebeat_use_apt_repo` value to `false`, then (optionally)
 adjust the value of `filebeat_deb_baseurl` (which has a default value set for you).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,5 +72,7 @@ filebeat_config: |
 
   {{filebeat_config_logging}}
 
+filebeat_use_apt_repo: True
 
 # vi:ts=2:sw=2:et:ft=yaml
+

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -5,17 +5,27 @@
     state=present
     url="{{filebeat_apt_key}}"
 
-- name : FileBeat APT Repository
-  apt_repository:
-    state=present
-    repo="deb {{filebeat_apt_repository}} stable main"
-    update_cache=yes
+- block:
+  - name : FileBeat APT Repository
+    apt_repository:
+      state=present
+      repo="deb {{filebeat_apt_repository}} stable main"
+      update_cache=yes
+  
+  - name: Install FileBeat (Debian)
+    apt:
+      state="{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
+      name="{{item}}"
+    with_items: "{{ filebeat_packages }}"
+    notify: filebeat restart
+  when: filebeat_use_apt_repo
 
-- name: Install FileBeat (Debian)
+- name: Install FileBeat from URL
   apt:
-    state="{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
-    name="{{item}}"
-  with_items: filebeat_packages
+    deb="{{ filebeat_deb_baseurl }}/{{ item }}-{{ filebeat_version }}-amd64.deb"
+    state=present
+  with_items: "{{ filebeat_packages }}"
   notify: filebeat restart
+  when: not filebeat_use_apt_repo
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -5,19 +5,19 @@
     state=present
     url="{{filebeat_apt_key}}"
 
-- block:
-  - name : FileBeat APT Repository
-    apt_repository:
-      state=present
-      repo="deb {{filebeat_apt_repository}} stable main"
-      update_cache=yes
+- name : FileBeat APT Repository
+  apt_repository:
+    state=present
+    repo="deb {{filebeat_apt_repository}} stable main"
+    update_cache=yes
+  when: filebeat_use_apt_repo
   
-  - name: Install FileBeat (Debian)
-    apt:
-      state="{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
-      name="{{item}}"
-    with_items: "{{ filebeat_packages }}"
-    notify: filebeat restart
+- name: Install FileBeat (Debian)
+  apt:
+    state="{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
+    name="{{item}}"
+  with_items: "{{ filebeat_packages }}"
+  notify: filebeat restart
   when: filebeat_use_apt_repo
 
 - name: Install FileBeat from URL

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,6 +8,7 @@ filebeat_repo_version:   "{{filebeat_v_major}}.{{ ((filebeat_v_major|int) > 1) |
 
 filebeat_apt_key: https://packages.elastic.co/GPG-KEY-elasticsearch
 filebeat_apt_repository: "https://packages.elastic.co/beats/apt"
+filebeat_deb_baseurl: "https://download.elastic.co/beats/filebeat"
 
 filebeat_packages:
   - filebeat


### PR DESCRIPTION
This commit enables installation of filebeat via an URL to the deb
package !

I hope it's okay to contribute. I really like your role ! 
I'd even volunteer to write the documentation ;-)
