### PR TITLE
Feature: Install templates alongside filebeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ filebeat_config: |
   {{filebeat_config_logging}}
 ```
 
+FileBeat templates (a list of templates to install).
+
+    filebeat_templates: []
+
 ## Usage
 ```yaml
     - hosts: logging

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ filebeat_config: |
 ```
 
 FileBeat templates (a list of templates to install).
+These templates will be copied to the /etc/filebeat directory
+and can be used in the elasticsearch output for example.
+
+https://www.elastic.co/guide/en/beats/filebeat/current/elasticsearch-output.html#_template
 
     filebeat_templates: []
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,5 +79,8 @@ filebeat_config: |
 
 filebeat_use_apt_repo: True
 
+# List of template files to copy 
+filebeat_templates: []
+
 # vi:ts=2:sw=2:et:ft=yaml
 

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -20,10 +20,17 @@
   notify: filebeat restart
   when: filebeat_use_apt_repo
 
-- name: Install FileBeat from URL
+- name: Download FileBeat .deb
+  get_url:
+    src: "{{ filebeat_deb_baseurl }}/{{ item }}-{{ filebeat_version }}-amd64.deb"
+    dest: "/var/cache/apt/archives/{{ item }}-{{ filebeat_version }}-amd64.deb"
+  with_items: "{{ filebeat_packages }}"
+  when: not filebeat_use_apt_repo
+
+- name: Install FileBeat .deb
   apt:
-    deb="{{ filebeat_deb_baseurl }}/{{ item }}-{{ filebeat_version }}-amd64.deb"
-    state=present
+    deb: "/var/cache/apt/archives/{{ item }}-{{ filebeat_version }}-amd64.deb"
+    state: present
   with_items: "{{ filebeat_packages }}"
   notify: filebeat restart
   when: not filebeat_use_apt_repo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,6 +12,10 @@
   sudo: true
   tags: filebeat_config
 
+- include: template.yml
+  sudo: true
+  tags: filebeat_template
+
 - service:
     name: filebeat
     enabled: yes

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -2,11 +2,11 @@
 
 - name: Filebeat template file(s)
   copy:
-    src={{ item }}
-    dest="{{ filebeat_config_file | dirname }}/{{ item | basename }}"
-    owner="{{filebeat_user}}"
-    group="{{filebeat_group}}"
-    mode=0640
+    src: "{{ item }}"
+    dest:  "{{ filebeat_config_file | dirname }}/{{ item | basename }}"
+    owner: "{{ filebeat_user }}"
+    group: "{{ filebeat_group }}"
+    mode: 0640
   with_items: "{{ filebeat_templates }}"
   notify: filebeat restart
 

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -1,0 +1,13 @@
+---
+
+- name: Filebeat template file(s)
+  copy:
+    src={{ item }}
+    dest="{{ filebeat_config_file | dirname }}/{{ item | basename }}"
+    owner="{{filebeat_user}}"
+    group="{{filebeat_group}}"
+    mode=0640
+  with_items: "{{ filebeat_templates }}"
+  notify: filebeat restart
+
+# vi:ts=2:sw=2:et:ft=yaml


### PR DESCRIPTION
Since filebeat in version 5.x implements json decoding on input, templates become more important if sending directly to Elasticsearch. 
