### PR TITLE
Add possibility to skip config tasks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ filebeat_start_at_boot: True
 #  Make sure you know what this implies.
 filebeat_upgrade: false
 
+filebeat_config_enabled: True
+
 filebeat_config_file: /etc/filebeat/filebeat.yml
 
 filebeat_config_registry_file: /var/lib/filebeat/registry

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,7 @@
 - include: config.yml
   become: true
   tags: filebeat_config
+  when: filebeat_config_enabled
 
 - include: template.yml
   become: true


### PR DESCRIPTION
To not bloat the playbook it would be nice to skip the configuration logic and add the configuration file manually.