### PR TITLE
use the apt key only of you're installing from a repository

### DIFF
--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -4,6 +4,7 @@
   apt_key:
     state=present
     url="{{filebeat_gpg_key}}"
+    when: filebeat_use_repo
 
 - name : FileBeat APT Repository
   apt_repository:

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -4,7 +4,7 @@
   apt_key:
     state=present
     url="{{filebeat_gpg_key}}"
-    when: filebeat_use_repo
+  when: filebeat_use_repo
 
 - name : FileBeat APT Repository
   apt_repository:


### PR DESCRIPTION
The apt-key should get installed only if you're using the method of installing the filebeat package from a repository.