### PR TITLE
Release 6.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ install:
 script:
   # Test functionality with default values
   - ansible-playbook tests/test_defaults.yml -i localhost, --syntax-check 
-  - ansible-playbook tests/test_defaults.yml -i localhost, --connection=local --sudo
+  - ansible-playbook tests/test_defaults.yml -i localhost, --connection=local --become
 
   - ansible-playbook tests/test_url.yml -i localhost, --syntax-check 
-  - ansible-playbook tests/test_url.yml -i localhost, --connection=local --sudo
+  - ansible-playbook tests/test_url.yml -i localhost, --connection=local --become
 
   - ansible-playbook tests/test_template.yml -i localhost, --syntax-check 
-  - ansible-playbook tests/test_template.yml -i localhost, --connection=local --sudo
+  - ansible-playbook tests/test_template.yml -i localhost, --connection=local --become
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2018-07-03: 6.0.0
+  - Role version to match major filebeat releases
+  - Install specific filebeat version from a repository
+  - New config section `setup`
+  - Add processors
+  - Drop vagrant tests for Ubuntu precise
+
 ## 2016-12-22: 3.0.2
   - Remove become / sudo from tasks
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An Ansible Role that installs FileBeat on Red Hat/CentOS or Debian/Ubuntu.
 
   * EL / Centos (6 / 7)
   * Debian (Wheezy / Jessie)
-  * Ubuntu (Precise / Trusty)
+  * Ubuntu (Trusty / Xenial)
   * Solaris
 
 ## Role Variables
@@ -33,7 +33,7 @@ Create the `filebeat` user and group.
 
 FileBeat version to use.
 
-    filebeat_version: 5.x
+    filebeat_version: 6.3.0
 
 Make use of the FileBeat apt repo.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,9 @@
 VAGRANTFILE_API_VERSION = '2'
 
+ANSIBLE_VERSION = "2.5.0"
+
+ANSIBLE_ROLE = 'ansible-role-filebeat'
+
 EPEL_REPO_6 = '''
 [epel]
 name     = EPEL 6 - \$basearch
@@ -26,62 +30,39 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize [ 'modifyvm', :id, '--natdnsproxy1', 'on' ]
   end
       
-  config.vm.define 'ubuntu' do |ubuntu|
-    ubuntu.vm.box      = 'ubuntu/trusty64'
-    ubuntu.vm.hostname = 'ubuntu'
+  
+  config.vm.define 'ubuntu-xenial' do |ubuntu_x|
+    ubuntu_x.vm.box      = 'ubuntu/xenial64'
+    #ubuntu_x.vm.hostname = 'ubuntu'
     
-    ubuntu.vm.provision 'shell', inline: 'apt-get update'
-    ubuntu.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
-    ubuntu.vm.provision 'shell', inline: 'pip install ansible==2.2.0.0 ansible-lint jinja2'
+    ubuntu_x.vm.provision 'shell', inline: 'apt-get update'
+    ubuntu_x.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
+    ubuntu_x.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} jinja2"
+    ubuntu_x.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
 
-    ubuntu.vm.provision 'ansible' do |ansible| 
+    ubuntu_x.vm.provision 'ansible_local' do |ansible| 
       ansible.playbook = 'tests/test_vagrant.yml'
       ansible.extra_vars = {
-        filebeat_user:  'root',
-        filebeat_group: 'root',
-        filebeat_create_user: false,
       }
     end
     
   end
 
-  config.vm.define 'ubuntu-precise' do |ubuntu_p|
-    ubuntu_p.vm.box      = 'ubuntu/precise64'
-    ubuntu_p.vm.hostname = 'ubuntu-precise'
+  config.vm.define 'ubuntu-trusty' do |ubuntu_t|
+    ubuntu_t.vm.box      = 'ubuntu/trusty64'
+    ubuntu_t.vm.hostname = 'ubuntu'
     
-    ubuntu_p.vm.provision 'shell', inline: 'apt-get update'
-    ubuntu_p.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
-    ubuntu_p.vm.provision 'shell', inline: 'pip install ansible==2.2.0.0 ansible-lint jinja2'
+    ubuntu_t.vm.provision 'shell', inline: 'apt-get update'
+    ubuntu_t.vm.provision 'shell', inline: 'apt-get install -y -qq  python-pip libffi-dev libssl-dev python-dev'
+    ubuntu_t.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} jinja2"
+    ubuntu_t.vm.provision 'shell', inline: "ln -sf /vagrant /vagrant/#{ANSIBLE_ROLE}"
 
-    ubuntu_p.vm.provision 'ansible' do |ansible| 
+    ubuntu_t.vm.provision 'ansible_local' do |ansible| 
       ansible.playbook = 'tests/test_vagrant.yml'
       ansible.extra_vars = {
-        filebeat_user:  'root',
-        filebeat_group: 'root',
-        filebeat_create_user: false,
       }
     end
     
-  end
-
-  config.vm.define 'centos-6' do |centos6|
-    centos6.vm.box      = "puppetlabs/centos-6.6-64-nocm"
-    centos6.vm.hostname = 'centos-6'
-
-    centos6.vm.provision 'shell', inline: 'yum install -y ca-certificates'
-    centos6.vm.provision 'shell', inline: "echo \"#{EPEL_REPO_6}\" > /etc/yum.repos.d/epel.repo"
-    centos6.vm.provision 'shell', inline: 'yum install -y python-pip python-devel gcc libffi-devel openssl-devel'
-    centos6.vm.provision 'shell', inline: 'pip install -q pip --upgrade'
-    centos6.vm.provision 'shell', inline: 'pip install -q ansible==2.2.0.0 ansible-lint jinja2'
-
-    centos6.vm.provision 'ansible' do |ansible| 
-      ansible.playbook   = 'tests/test_vagrant.yml'
-      ansible.extra_vars = {
-        filebeat_user:  'root',
-        filebeat_group: 'root',
-        filebeat_create_user: false,
-      }
-    end
   end
 
   config.vm.define 'centos-7' do |centos7|
@@ -92,7 +73,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     centos7.vm.provision 'shell', inline: "echo \"#{EPEL_REPO_7}\" > /etc/yum.repos.d/epel.repo"
     centos7.vm.provision 'shell', inline: 'yum install -y python-pip python-devel gcc libffi-devel openssl-devel'
     centos7.vm.provision 'shell', inline: 'pip install -q pip --upgrade'
-    centos7.vm.provision 'shell', inline: 'pip install -q ansible==2.2.0.0 ansible-lint jinja2'
+    centos7.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
 
     centos7.vm.provision 'ansible' do |ansible| 
       ansible.playbook = 'tests/test_vagrant.yml'
@@ -103,6 +84,27 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       }
     end
   end
+
+  config.vm.define 'centos-6' do |centos6|
+    centos6.vm.box      = "puppetlabs/centos-6.6-64-nocm"
+    centos6.vm.hostname = 'centos-6'
+
+    centos6.vm.provision 'shell', inline: 'yum install -y ca-certificates'
+    centos6.vm.provision 'shell', inline: "echo \"#{EPEL_REPO_6}\" > /etc/yum.repos.d/epel.repo"
+    centos6.vm.provision 'shell', inline: 'yum install -y python-pip python-devel gcc libffi-devel openssl-devel'
+    centos6.vm.provision 'shell', inline: 'pip install -q pip --upgrade'
+    centos6.vm.provision 'shell', inline: "pip install -q ansible==#{ANSIBLE_VERSION} ansible-lint jinja2"
+
+    centos6.vm.provision 'ansible_local' do |ansible| 
+      ansible.playbook   = 'tests/test_vagrant.yml'
+      ansible.extra_vars = {
+        filebeat_user:  'root',
+        filebeat_group: 'root',
+        filebeat_create_user: false,
+      }
+    end
+  end
+
 
 end
   

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,14 +11,18 @@ filebeat_group: root
 filebeat_create_user: true
 
 # Filebeat version to use
-# 
-filebeat_version: 6.x
+#  The package repository is build upon major and minor versions
+#
+filebeat_version: 6.3.0
+filebeat_version_repo: "{{filebeat_version|regex_replace('^([0-9]+)\\..*$', '\\1')}}.x"
 
 filebeat_gpg_key: https://artifacts.elastic.co/GPG-KEY-elasticsearch
 
-filebeat_baseurl: "https://artifacts.elastic.co"
-filebeat_repo_baseurl: "{{filebeat_baseurl}}/packages/{{filebeat_version}}"
+filebeat_baseurl:         "https://artifacts.elastic.co"
+filebeat_repo_baseurl:    "{{filebeat_baseurl}}/packages/{{filebeat_version_repo}}"
 filebeat_package_baseurl: "{{filebeat_baseurl}}/downloads/beats/filebeat"
+
+filebeat_arch: "{{ (ansible_architecture == 'x86_64') | ternary('amd64', 'i386') }}"
 
 # Filebeat Solaris url
 #

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -1,39 +1,39 @@
 ---
 
-- name: Elastic APT Key
-  apt_key:
-    state=present
-    url="{{filebeat_gpg_key}}"
+- block:
+
+  - name: Elastic APT Key
+    apt_key:
+      state: present
+      url:   "{{filebeat_gpg_key}}"
+
+  - name : FileBeat APT Repository
+    apt_repository:
+      state: present
+      repo:  "deb {{filebeat_apt_repository}} stable main"
+      update_cache: yes
+
+  - name: Install FileBeat (Debian)
+    apt:
+      state: "{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
+      name: "{{filebeat_package}}"
+    notify: filebeat restart
+
   when: filebeat_use_repo
 
-- name : FileBeat APT Repository
-  apt_repository:
-    state=present
-    repo="deb {{filebeat_apt_repository}} stable main"
-    update_cache=yes
-  when: filebeat_use_repo
+- block:
 
-- name: Install FileBeat (Debian)
-  apt:
-    state="{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
-    name="{{item}}"
-  with_items: "{{filebeat_packages}}"
-  notify: filebeat restart
-  when: filebeat_use_repo
+  - name: Download FileBeat DEB
+    get_url:
+      url: "{{filebeat_package_url}}"
+      dest: "/var/cache/apt/archives/filebeat-{{filebeat_version}}-amd64.deb"
 
-- name: Download FileBeat DEB
-  get_url:
-    url: "{{filebeat_package_baseurl}}/{{item}}-{{filebeat_version}}-amd64.deb"
-    dest: "/var/cache/apt/archives/{{item}}-{{filebeat_version}}-amd64.deb"
-  with_items: "{{filebeat_packages}}"
-  when: not filebeat_use_repo
+  - name: Install FileBeat DEB
+    apt:
+      deb: "/var/cache/apt/archives/filebeat-{{filebeat_version}}-amd64.deb"
+      state: present
+    notify: filebeat restart
 
-- name: Install FileBeat DEB
-  apt:
-    deb: "/var/cache/apt/archives/{{item}}-{{filebeat_version}}-amd64.deb"
-    state: present
-  with_items: "{{filebeat_packages}}"
-  notify: filebeat restart
   when: not filebeat_use_repo
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -1,34 +1,38 @@
 ---
 
-- name: FileBeat Yum Repository
-  copy:
-    dest="/etc/yum.repos.d/filebeat-{{filebeat_version}}.repo"
-    content="{{filebeat_yum_config}}"
-    owner="root"
-    group="root"
-    mode="0644"
+- block:
 
-- name: Install FileBeat (RedHat)
-  yum:
-    state="{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
-    name="{{item}}"
-    update_cache=yes
-  with_items: "{{filebeat_packages}}"
-  notify: filebeat restart
+  - name: FileBeat Yum Repository
+    copy:
+      dest:    "/etc/yum.repos.d/filebeat-{{filebeat_version}}.repo"
+      content: "{{filebeat_yum_config}}"
+      owner:   "root"
+      group:   "root"
+      mode:    "0644"
 
-- name: Download FileBeat RPM
-  get_url:
-    url: "{{filebeat_package_baseurl}}/{{item}}-{{filebeat_version}}-{{ansible_architecture}}.rpm"
-    dest: "/var/cache/yum/{{ansible_architecture}}/{{item}}-{{filebeat_version}}-{{ansible_architecture}}.rpm"
-  with_items: "{{filebeat_packages}}"
+  - name: Install FileBeat (RedHat)
+    yum:
+      state: "{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
+      name: "{{filebeat_package}}"
+      update_cache: yes
+    notify: filebeat restart
+
+  when: filebeat_use_repo
+
+- block:
+
+  - name: Download FileBeat RPM
+    get_url:
+      url: "{{filebeat_package_url}}"
+      dest: "/var/cache/yum/{{ansible_architecture}}/filebeat-{{filebeat_version}}-{{ansible_architecture}}.rpm"
+
+  - name: Install FileBeat from RPM
+    yum:
+      state: present
+      name: "/var/cache/yum/{{ansible_architecture}}/filebeat-{{filebeat_version}}-{{ansible_architecture}}.rpm"
+    notify: filebeat restart
+
   when: not filebeat_use_repo
 
-- name: Install FileBeat from RPM
-  yum:
-    name: "/var/cache/yum/{{ansible_architecture}}/{{item}}-{{filebeat_version}}-{{ansible_architecture}}.rpm"
-    state: present
-  with_items: "{{filebeat_packages}}"
-  notify: filebeat restart
-  when: not filebeat_use_repo
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tests/test_template.yml
+++ b/tests/test_template.yml
@@ -15,7 +15,7 @@
   pre_tasks:
 
     - name: Uninstall previous filebeat version
-      apt:
+      package:
         name: 'filebeat'
         state: absent
 

--- a/tests/test_url.yml
+++ b/tests/test_url.yml
@@ -9,6 +9,12 @@
     - filebeat_use_repo: false
     - filebeat_version: 6.2.4
 
+  pre_tasks:
+    - name: Uninstall previous filebeat version
+      package:
+        name: 'filebeat'
+        state: absent
+
   roles:
     - ansible-role-filebeat
 

--- a/tests/test_vagrant.yml
+++ b/tests/test_vagrant.yml
@@ -1,12 +1,14 @@
 ---
 
-- name: Defaults
+- name: Install Filebeat from URL
   hosts: all
   become: yes
 
   roles:
     - {
         role: ansible-role-filebeat,
+        filebeat_use_repo: false,
+        filebeat_version: 6.0.0
       }
 
   tasks:
@@ -18,15 +20,13 @@
         msg: "{{r_version.stdout}}"
 
 
-- name: Filebeat from URL
+- name: Defaults
   hosts: all
   become: yes
 
   roles:
     - {
-        role: ansible-role-filebeat,
-        filebeat_use_repo: false,
-        filebeat_version: '6.2.4'
+        role: ansible-role-filebeat
       }
 
   tasks:
@@ -46,14 +46,14 @@
     - {
         role: ansible-role-filebeat,
         filebeat_use_repo: false,
-        filebeat_version: '5.6.9'
+        filebeat_version: '5.6.9',
         filebeat_templates: [ templates/filebeat.template.json ]
       }
 
   pre_tasks:
 
     - name: Uninstall previous filebeat version
-      apt:
+      package:
         name: 'filebeat'
         state: absent
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,9 +1,9 @@
 ---
 
-filebeat_apt_key: "{{filebeat_gpg_key}}"
 filebeat_apt_repository: "{{filebeat_repo_baseurl}}/apt"
 
-filebeat_packages:
-  - filebeat
+filebeat_package:        "filebeat={{filebeat_version}}"
+
+filebeat_package_url:    "{{filebeat_package_baseurl}}/filebeat-{{filebeat_version}}-{{filebeat_arch}}.deb"
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -10,8 +10,9 @@ filebeat_yum_config: |
   gpgkey={{filebeat_gpg_key}}
   enabled=1
 
-filebeat_packages:
-  - filebeat
+filebeat_package: "filebeat-{{filebeat_version}}"
+
+filebeat_package_url: "{{filebeat_package_baseurl}}/filebeat-{{filebeat_version}}-{{ansible_architecture}}.rpm"
 
 #filebeat_defaults_cfg: /etc/sysconfig/filebeat
 


### PR DESCRIPTION
## 2018-07-03: 6.0.0

  - Role version to match major filebeat releases
  - Install specific filebeat version from a repository
  - New config section `setup`
  - Add processors
  - Drop vagrant tests for Ubuntu precise