### PR TITLE
Fix Ansible lint issues with whitespace and pipefail

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -4,11 +4,11 @@
 
 - name: Filebeat configuration file
   template:
-    src=etc/filebeat/filebeat.yml.j2
-    dest="{{filebeat_config_file}}"
-    owner="{{filebeat_user}}"
-    group="{{filebeat_group}}"
-    mode=0640
+    src: etc/filebeat/filebeat.yml.j2
+    dest: "{ {filebeat_config_file }}"
+    owner: "{{ filebeat_user }}"
+    group: "{{ filebeat_group }}"
+    mode: 0640
   notify: filebeat restart
 
 # vi:ts=2:sw=2:et:ft=yaml

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -5,18 +5,18 @@
   - name: Elastic APT Key
     apt_key:
       state: present
-      url:   "{{filebeat_gpg_key}}"
+      url:   "{{ filebeat_gpg_key }}"
 
   - name: FileBeat APT Repository
     apt_repository:
       state: present
-      repo:  "deb {{filebeat_apt_repository}} stable main"
+      repo:  "deb {{ filebeat_apt_repository }} stable main"
       update_cache: yes
 
   - name: Install FileBeat (Debian)
     apt:
       state: "{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
-      name: "{{filebeat_package}}"
+      name: "{{ filebeat_package }}"
     notify: filebeat restart
 
   when: filebeat_use_repo
@@ -25,12 +25,12 @@
 
   - name: Download FileBeat DEB
     get_url:
-      url: "{{filebeat_package_url}}"
-      dest: "/var/cache/apt/archives/filebeat-{{filebeat_version}}-amd64.deb"
+      url: "{{ filebeat_package_url }}"
+      dest: "/var/cache/apt/archives/filebeat-{{ filebeat_version }}-amd64.deb"
 
   - name: Install FileBeat DEB
     apt:
-      deb: "/var/cache/apt/archives/filebeat-{{filebeat_version}}-amd64.deb"
+      deb: "/var/cache/apt/archives/filebeat-{{ filebeat_version }}-amd64.deb"
       state: present
     notify: filebeat restart
 

--- a/tasks/install/RedHat.yml
+++ b/tasks/install/RedHat.yml
@@ -4,8 +4,8 @@
 
   - name: FileBeat Yum Repository
     copy:
-      dest:    "/etc/yum.repos.d/filebeat-{{filebeat_version}}.repo"
-      content: "{{filebeat_yum_config}}"
+      dest:    "/etc/yum.repos.d/filebeat-{{ filebeat_version }}.repo"
+      content: "{{ filebeat_yum_config }}"
       owner:   "root"
       group:   "root"
       mode:    "0644"
@@ -13,7 +13,7 @@
   - name: Install FileBeat (RedHat)
     yum:
       state: "{{ (filebeat_upgrade) | ternary('latest', 'present') }}"
-      name: "{{filebeat_package}}"
+      name: "{{ filebeat_package }}"
       update_cache: yes
     notify: filebeat restart
 
@@ -23,13 +23,13 @@
 
   - name: Download FileBeat RPM
     get_url:
-      url: "{{filebeat_package_url}}"
-      dest: "/var/cache/yum/{{ansible_architecture}}/filebeat-{{filebeat_version}}-{{ansible_architecture}}.rpm"
+      url: "{{ filebeat_package_url }}"
+      dest: "/var/cache/yum/{{ ansible_architecture }}/filebeat-{{ filebeat_version }}-{{ ansible_architecture }}.rpm"
 
   - name: Install FileBeat from RPM
     yum:
       state: present
-      name: "/var/cache/yum/{{ansible_architecture}}/filebeat-{{filebeat_version}}-{{ansible_architecture}}.rpm"
+      name: "/var/cache/yum/{{ ansible_architecture }}/filebeat-{{ filebeat_version }}-{{ ansible_architecture }}.rpm"
     notify: filebeat restart
 
   when: not filebeat_use_repo

--- a/tasks/install/Solaris.yml
+++ b/tasks/install/Solaris.yml
@@ -22,7 +22,8 @@
     state: present
 
 - name: filebeat | Install Filebeat service
-  shell: (svccfg import /opt/filebeat/etc/filebeat.xml) && (svcs | grep filebeat) > /opt/filebeat/service.created
+  shell: |
+    set -eo pipefail (svccfg import /opt/filebeat/etc/filebeat.xml) && (svcs | grep filebeat) > /opt/filebeat/service.created
   args:
     creates: /opt/filebeat/service.created
   when: filebeat_start_at_boot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Include OS Family vars
-  include_vars: "{{ansible_os_family}}.yml"
+  include_vars: "{{ ansible_os_family }}.yml"
   tags: always
 
 - include: install.yml

--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -8,7 +8,7 @@
     group: "{{ filebeat_group }}"
     mode: 0640
   with_items: "{{ filebeat_templates }}"
-  when:  filebeat_version is version('6.0', '<') 
+  when:  filebeat_version is version('6.0', '<')
   notify: filebeat restart
 
 - name: Filebeat fields template


### PR DESCRIPTION
We use this role quite extensively at work and are very grateful for it :pray: I wanted to contribute back a very simple change to allow it to pass [`ansible-lint` rules](https://docs.ansible.com/ansible-lint/rules/default_rules.html). This involves simple changes:

1. Add whitespace around variable names in `{{ ... }}` (206)
1. Remove trailing whitespace (201)
1. Set `pipefail` for `shell`  module (306)

Thanks, Bruce

Signed-off-by: Bruce Becker <brucellino@gmail.com>